### PR TITLE
Fix no-build issue on osx

### DIFF
--- a/Point Cloud Iterate Excluding Search Point VEXpression.sublime-snippet
+++ b/Point Cloud Iterate Excluding Search Point VEXpression.sublime-snippet
@@ -6,7 +6,7 @@
 float search_rad = ${1:10.0};
 int   max_points = ${2:10};
 
-int handle = pcopen(@OpInput1, "P", @P, search_radius, max_points+1);
+int handle = pcopen(@OpInput1, "P", @P, search_rad, max_points+1);
 
 int near_pt;
 vector near_p;

--- a/VEX Build.sublime-build
+++ b/VEX Build.sublime-build
@@ -1,5 +1,9 @@
 {
     "cmd": ["python", "-u", "$packages/VEX Syntax/src/compile_and_run.py", "$file"],
     "shell": true,
-    "selector": "source.vex"
+    "selector": "source.vex",
+    "osx":
+    {
+        "cmd": ["/Library/Frameworks/Houdini.framework/Versions/CUrrent/Resources/bin/vcc '${file}' -o '${file_path}/${file_base_name}.vex'"]
+    }
 }


### PR DESCRIPTION
As osx has a Versions/Current directory we might not need to fire run "compile_and_run.py" to figure out the current version. Running vcc directly from "VEX Build.sublime-build" seems like a better solution.
https://github.com/WhileRomeBurns/VEX_Syntax/issues/2
